### PR TITLE
Fix segmentation fault caused by std::string instance passed to memcpy

### DIFF
--- a/Samples/OpenGL/Demo/proj.linux.cmake/src/LAppDelegate.cpp
+++ b/Samples/OpenGL/Demo/proj.linux.cmake/src/LAppDelegate.cpp
@@ -312,11 +312,11 @@ void LAppDelegate::SetRootDirectory()
     std::string pathString(path);
 
     pathString = pathString.substr(0, pathString.rfind("Demo"));
-    Csm::csmVector<string> splitStrings = this->Split(pathString, '/');
+    std::vector<string> splitStrings = this->Split(pathString, '/');
 
     this->_rootDirectory = "";
 
-    for(int i = 0; i < splitStrings.GetSize(); i++)
+    for(int i = 0; i < splitStrings.size(); i++)
     {
         this->_rootDirectory = this->_rootDirectory + "/" +splitStrings[i];
     }
@@ -324,9 +324,9 @@ void LAppDelegate::SetRootDirectory()
     this->_rootDirectory += "/";
 }
 
-Csm::csmVector<string> LAppDelegate::Split(const std::string& baseString, char delimiter)
+std::vector<string> LAppDelegate::Split(const std::string& baseString, char delimiter)
 {
-    Csm::csmVector<string> elems;
+    std::vector<string> elems;
     stringstream ss(baseString);
     string item;
 
@@ -334,7 +334,7 @@ Csm::csmVector<string> LAppDelegate::Split(const std::string& baseString, char d
     {
         if(!item.empty())
         {
-            elems.PushBack(item);
+            elems.push_back(item);
         }
     }
 

--- a/Samples/OpenGL/Demo/proj.linux.cmake/src/LAppDelegate.hpp
+++ b/Samples/OpenGL/Demo/proj.linux.cmake/src/LAppDelegate.hpp
@@ -7,10 +7,10 @@
 
 #pragma once
 
+#include <vector>
 #include <string>
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
-#include "Type/csmVector.hpp"
 #include "LAppAllocator.hpp"
 
 class LAppView;
@@ -130,7 +130,7 @@ private:
     /**
      * @brief   文字列を指定の文字で切り分ける
      */
-    Csm::csmVector<std::string> Split(const std::string& baseString, char delim);
+    std::vector<std::string> Split(const std::string& baseString, char delim);
 
     LAppAllocator _cubismAllocator;              ///< Cubism3 Allocator
     Csm::CubismFramework::Option _cubismOption;  ///< Cubism3 Option


### PR DESCRIPTION
In the implementation of csmVector, when memory is reallocated,
the values in the previous pointer is copied directly using
memcpy(). This is not safe to use with std::string. Instances
created using placement new (as it is inside csmVector) must be
destroyed by calling their destructor, before the underlying
memory storage can be manipulated.

std::vector handles memory correctly, and switching to std::vector
resolves the segmentation fault.