### PR TITLE
[RC] Update to Cubism 4 SDK for Native R3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.3-beta.1] - 2021-05-13
+
+### Added
+
+* Add the sample for Cocos2d-x v4.0.
+
+### Removed
+
+* Obsolete the sample for Cocos2d-x v3.x.
+
+### Fixed
+
+* Fix setup scripts for Cocos2d-x.
+  * Changed from xcopy to robocopy and improved to be able to place in a deep hierarchy.
+* Fixed initial window size display misalignment when scaling is set in D3D11.
+
+
 ## [4-r.2] - 2021-02-17
 
 ### Added
@@ -106,6 +123,7 @@ See [Core Changelog] for details.
 * What was `Package.json` is currently being changed to`cubism-info.yml`.
 
 
+[4-r.3-beta.1]: https://github.com/Live2D/CubismNativeSamples/compare/4-r.2...4-r.3-beta.1
 [4-r.2]: https://github.com/Live2D/CubismNativeSamples/compare/4-r.1...4-r.2
 [4-r.1]: https://github.com/Live2D/CubismNativeSamples/compare/4-beta.2.1...4-r.1
 [4-beta.2.1]: https://github.com/Live2D/CubismNativeSamples/compare/4-beta.2...4-beta.2.1

--- a/Core/CHANGELOG.md
+++ b/Core/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2021-03-09
+
+### Added
+* Add funtcions for Viewer.
+
+  * `csmGetParameterKeyCounts`
+  * `csmGetParameterKeyValues`
+
+### Changed
+
+* Update Core version to `04.01.0000`.
+
+
 ## 2020-01-30
 
 ### Added

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,6 +6,7 @@ Cubism Native Samples is included in Live2D Cubism Components.
 
 Cubism Native Samples は Live2D Cubism Components に含まれます。
 
+Cubism Native Samples 包括在 Live2D Cubism Components 中。
 
 ## Cubism SDK Release License
 
@@ -17,6 +18,9 @@ Cubism Native Samples は Live2D Cubism Components に含まれます。
 
 * [Cubism SDK リリースライセンス](https://www.live2d.com/ja/download/cubism-sdk/release-license/)
 
+如果您的企业在最近一个会计年度的销售额达到或超过1000万日元，您必须得到Cubism SDK的出版授权许可（出版许可协议）。
+
+* [Cubism SDK发行许可证](https://www.live2d.com/zh-CHS/download/cubism-sdk/release-license/)
 
 ## Live2D Open Software License
 
@@ -24,6 +28,7 @@ Live2D Cubism Components is available under Live2D Open Software License.
 
 * [Live2D Open Software License Agreement](https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html)
 * [Live2D Open Software 使用許諾契約書](https://www.live2d.com/eula/live2d-open-software-license-agreement_jp.html)
+* [Live2D Open Software 使用授权协议](https://www.live2d.com/eula/live2d-open-software-license-agreement_cn.html)
 
 
 ## Live2D Proprietary Software License
@@ -32,6 +37,7 @@ Live2D Cubism Core is available under Live2D Proprietary Software License.
 
 * [Live2D Proprietary Software License Agreement](https://www.live2d.com/eula/live2d-proprietary-software-license-agreement_en.html)
 * [Live2D Proprietary Software 使用許諾契約書](https://www.live2d.com/eula/live2d-proprietary-software-license-agreement_jp.html)
+* [Live2D Proprietary Software 使用授权协议](https://www.live2d.com/eula/live2d-proprietary-software-license-agreement_cn.html)
 
 
 ## Free Material License
@@ -40,6 +46,7 @@ Live2D models listed below are available under Free Material License.
 
 * [Free Material License Agreement](https://www.live2d.com/eula/live2d-free-material-license-agreement_en.html)
 * [無償提供マテリアルの使用許諾契約書](https://www.live2d.com/eula/live2d-free-material-license-agreement_jp.html)
+* [无偿提供素材使用授权协议](https://www.live2d.com/eula/live2d-free-material-license-agreement_cn.html)
 
 ```
 Samples/Resources/Haru

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,3 +1,23 @@
+## [制限事項] Apple製品及びmacOS Big Surへの対応状況について (2021-04-15)
+
+本 Cubism SDK につきまして、 `macOS Big Sur 11.2.3` 環境にてビルドが通過できることを確認しております。
+Apple Sillicon版のmacにつきましては、引き続き全ての Cubism 製品において対応しておりません。ご了承ください。
+
+
+## [制限事項] Cocos2d-x v4.0 の Linux(Ubuntu)サンプルビルドについて (2021-04-15)
+
+Cocos2d-x v4.0 は `Ubuntu 20.04` ビルドに対応しておりません。
+使用する際は以下の回避方法を確認し、いずれかを適用してご利用いただきますようお願いいたします。
+
+### 回避方法
+
+* `Ubuntu 16.04` または `Ubuntu 18.04` を使用する
+
+* 以下issueを確認し、`Cocos2d-x v4.0` で使用されている `libchipmunk` ライブラリを差し替える
+  * [cocos2d/cocos2d-x linking error when integrating with libchipmunk on linux#20471](https://github.com/cocos2d/cocos2d-x/issues/20471)
+  * WARNING: この回避方法を使用してビルドしたプロジェクトはいかなる場合でも保守いたしかねます
+
+
 ## [注意事項] Visual Studio 2013 ご利用時の OpenGL サンプルビルドについて (2021-02-17)
 
 `Visual Studio 2013` を使用した `OpenGL` サンプルビルドでは、`setup_glew_glfw.bat` をそのまま使用してビルドすると `GLEW` にてリンクエラーが発生します。
@@ -11,16 +31,6 @@
 
 * `GLEW 2.1.0` を使用する場合
   * `setup_glew_glfw_vs2013.bat` を使用して `thirdParty` のセットアップを行う
-
-
-## [制限事項] macOS 11.0 Big Surへの対応状況について (2021-01-12)
-
-現在公開中のCubism SDKは、macOS 11.0 Big Surには対応しておりません。
-正常に動作できない可能性がありますので、OSのアップグレードをお控えいただきご利用いただきますようお願いいたします。
-現在対応検討中となりますが、対応バージョンや時期につきましては改めてお知らせいたします。
-
-またApple Sillicon版のmacにつきましても、全てのCubism 製品において対応しておりませんのでこちらも合わせてご了承ください。
-
 
 
 ## Cubism Core

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Cubism Native Samples
+# \[Beta Version\] Cubism Native Samples
 
 Live2D Cubism 4 Editor で出力したモデルを表示するアプリケーションのサンプル実装です。
 
 Cubism Native Framework および Live2D Cubism Core と組み合わせて使用します。
+
+**本 SDK は、 Beta バージョンとなります。先行して新機能を取り込んでいるため、不安定な挙動を示す場合がございます。安定した製品をお求めの方は、公式サイトから配布されている正式版のパッケージ又は `develop` `master` ブランチをご利用ください。**
+
+**\[Beta Version\] の SDK の不具合、各種ご意見等に関しましては、 Live2D コミュニティ にてご連絡ください。直接のコードに対する指摘、修正等は、直接 Pull requests としてご投稿ください。**
 
 
 ## ライセンス
@@ -92,20 +96,20 @@ Demo
 
 | 開発ツール | バージョン |
 | --- | --- |
-| Android Studio | 4.1.1 |
-| CMake | 3.19.3 |
+| Android Studio | 4.1.3 |
+| CMake | 3.20.1 |
 | Visual Studio 2013 | Update 5 |
 | Visual Studio 2015 | Update 3 |
-| Visual Studio 2017 | 15.9.31 |
-| Visual Studio 2019 | 16.8.4 |
-| XCode | 12.3 |
+| Visual Studio 2017 | 15.9.35 |
+| Visual Studio 2019 | 16.9.4 |
+| XCode | 12.4 |
 
 ### Android
 
 | Android SDK tools | バージョン |
 | --- | --- |
-| Android NDK | 22.0.7026061 |
-| Android SDK | 30.05 |
+| Android NDK | 22.1.7171670 |
+| Android SDK | 31.0.0 |
 | CMake | 3.10.2.4988404 |
 
 ### Linux
@@ -117,7 +121,7 @@ Demo
 | Red Hat | `centos:8` | 8.3.1 |
 | Debian | `ubuntu:16.04` | 5.4.0 |
 | Debian | `ubuntu:18.04` | 7.4.0 |
-| Debian | `ubuntu:20.04` | 8.3.1 |
+| Debian | `ubuntu:20.04` | 9.3.0 |
 
 #### Mesa ライブラリ
 
@@ -133,9 +137,9 @@ Demo
 
 | プラットフォーム | バージョン |
 | --- | --- |
-| iOS / iPadOS | 14.3 |
-| macOS | 10.15.7 |
-| Windows 10 | 2004 / 20H2 |
+| iOS / iPadOS | 14.5.1 |
+| macOS | 11.3.1 |
+| Windows 10 | 20H2 |
 
 ### Android
 

--- a/Samples/Cocos2d-x/Demo/CMakeLists.txt
+++ b/Samples/Cocos2d-x/Demo/CMakeLists.txt
@@ -145,7 +145,7 @@ elseif(WINDOWS)
       IMPORTED_LOCATION_DEBUG
         ${CORE_PATH}/lib/windows/x86/${MSVC_NUM}/Live2DCubismCore_${CRT}d.lib
       IMPORTED_LOCATION_RELEASE
-        ${CORE_PATH}/lib/windows/x86/${MSVC_NUM}/Live2DCubismCore_MD.lib
+        ${CORE_PATH}/lib/windows/x86/${MSVC_NUM}/Live2DCubismCore_${CRT}.lib
   )
 
 elseif(APPLE)
@@ -208,11 +208,13 @@ set_target_properties(Live2DCubismCore
 )
 
 # Specify Cubism Framework rendering.
-set(FRAMEWORK_SOURCE OpenGL)
+set(FRAMEWORK_SOURCE Cocos2d)
 # Add Cubism Framework.
 add_subdirectory(${FRAMEWORK_PATH} ${CMAKE_CURRENT_BINARY_DIR}/Framework)
 # Add definitions for Cubism Framework.
 target_compile_definitions(Framework PUBLIC CSM_TARGET_COCOS)
+use_cocos2dx_compile_define(Framework)
+use_cocos2dx_compile_options(Framework)
 
 # Mark app complie info and libs info.
 set(all_code_files ${GAME_HEADER} ${GAME_SOURCE})
@@ -241,15 +243,14 @@ setup_cocos_app_config(${APP_NAME})
 if(APPLE)
   set_target_properties(${APP_NAME} PROPERTIES RESOURCE "${APP_UI_RES}")
   if(MACOSX)
-    set_target_properties(${APP_NAME}
-      PROPERTIES
-        MACOSX_BUNDLE_INFO_PLIST
-          "${CMAKE_CURRENT_SOURCE_DIR}/proj.mac/src/Info.plist"
-    )
+    set_xcode_property(${APP_NAME} INFOPLIST_FILE "${COCOS2DX_ROOT_PATH}/templates/cpp-template-default/proj.ios_mac/mac/Info.plist")
     target_compile_definitions(Framework PUBLIC CSM_TARGET_MAC_GL)
+    set(COCOS_GLFW3 ${COCOS2DX_ROOT_PATH}/external/glfw3)
+    target_include_directories(Framework PUBLIC ${COCOS_GLFW3}/include/Mac)
+    target_include_directories(Framework PUBLIC ${COCOS2DX_ROOT_PATH}/cocos)
   elseif(IOS)
     # Add information aboud XCode project.
-    cocos_pak_xcode(${APP_NAME} INFO_PLIST iOSBundleInfo.plist.in)
+    set_xcode_property(${APP_NAME} INFOPLIST_FILE "${COCOS2DX_ROOT_PATH}/templates/cpp-template-default/proj.ios_mac/ios/Info.plist")
     set_xcode_property(${APP_NAME} ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon")
     set_xcode_property(${APP_NAME} DEVELOPMENT_TEAM "")
     set_xcode_property(${APP_NAME} CODE_SIGN_IDENTITY "iPhone Developer")
@@ -258,25 +259,32 @@ if(APPLE)
     set_xcode_property(${APP_NAME} ONLY_ACTIVE_ARCH "NO")
     set_xcode_property(${APP_NAME} ARCHS "arm64")
     target_compile_definitions(Framework PUBLIC CSM_TARGET_IPHONE_ES2)
+    target_include_directories(Framework PUBLIC ${COCOS2DX_ROOT_PATH}/cocos)
   endif()
 elseif(WINDOWS)
   cocos_copy_target_dll(${APP_NAME})
   target_compile_definitions(Framework PUBLIC CSM_TARGET_WIN_GL)
   # Specify glew directories for Cubism Framework.
   set(COCOS_GLEW ${COCOS2DX_ROOT_PATH}/external/win32-specific/gles)
+  set(COCOS_GLFW3 ${COCOS2DX_ROOT_PATH}/external/glfw3)
   target_include_directories(Framework PUBLIC ${COCOS_GLEW}/include/OGLES)
+  target_include_directories(Framework PUBLIC ${COCOS_GLFW3}/include/win32)
+  target_include_directories(Framework PUBLIC ${COCOS2DX_ROOT_PATH}/cocos)
 elseif(ANDROID)
   target_compile_definitions(Framework PUBLIC CSM_TARGET_ANDROID_ES2)
-  target_compile_definitions(${APP_NAME} PRIVATE CSM_TARGET_ANDROID_ES2)
+  target_include_directories(Framework PUBLIC ${COCOS2DX_ROOT_PATH}/cocos)
 elseif(LINUX)
+  set(COCOS_GLFW3 ${COCOS2DX_ROOT_PATH}/external/glfw3)
+  target_include_directories(Framework PUBLIC ${COCOS_GLFW3}/include/linux)
   target_compile_definitions(Framework PUBLIC CSM_TARGET_LINUX_GL)
+  target_include_directories(Framework PUBLIC ${COCOS2DX_ROOT_PATH}/cocos)
 endif()
 
 # Copy resources.
 if(LINUX OR WINDOWS)
-  set(APP_RES_DIR $<TARGET_FILE_DIR:${APP_NAME}>/Resources)
+  cocos_get_resource_path(APP_RES_DIR ${APP_NAME})
   cocos_copy_target_res(${APP_NAME}
-    COPY_TO ${APP_RES_DIR} FOLDERS ${GAME_RES_FOLDER}
+    LINK_TO ${APP_RES_DIR} FOLDERS ${GAME_RES_FOLDER}
   )
 endif()
 

--- a/Samples/Cocos2d-x/Demo/Classes/AppDelegate.cpp
+++ b/Samples/Cocos2d-x/Demo/Classes/AppDelegate.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright(c) Live2D Inc. All rights reserved.
  *
  * Use of this source code is governed by the Live2D Open Software license

--- a/Samples/Cocos2d-x/Demo/Classes/LAppLive2DManager.hpp
+++ b/Samples/Cocos2d-x/Demo/Classes/LAppLive2DManager.hpp
@@ -103,7 +103,7 @@ public:
      * @brief   画面を更新するときの処理
      *          モデルの更新処理および描画処理を行う
      */
-    void OnUpdate() const;
+    void OnUpdate(Csm::Rendering::CubismCommandBuffer_Cocos2dx* commandBuffer) const;
 
     /**
      * @brief   次のシーンに切り替える<br>
@@ -141,19 +141,15 @@ private:
      */
     void CreateShader();
 
-    /**
-     * @brief   CreateShader内部関数
-     */
-    bool CheckShader(GLuint shaderId);
-
     Csm::CubismMatrix44*        _viewMatrix;    ///< モデル描画に用いるView行列
     Csm::csmVector<LAppModel*>  _models;        ///< モデルインスタンスのコンテナ
     Csm::csmInt32               _sceneIndex;    ///< 表示するシーンのインデックス値
 
     // レンダリング先を別ターゲットにする方式の場合に使用
     SelectTarget _renderTarget;                 ///< レンダリング先の選択肢
-    GLuint _programId;                          ///< プリミティブを描画するためのシェーダID
     LAppSprite* _sprite;                        ///< テクスチャの単純描画クラス
-    Csm::Rendering::CubismOffscreenFrame_OpenGLES2* _renderBuffer;   ///< モードによってはCubismモデル結果をこっちにレンダリング
+    Csm::Rendering::CubismOffscreenFrame_Cocos2dx* _renderBuffer;   ///< モードによってはCubismモデル結果をこっちにレンダリング
     float _clearColor[4];                       ///< レンダリングターゲットのクリアカラー
+    cocos2d::backend::ProgramState* _programState;
+
 };

--- a/Samples/Cocos2d-x/Demo/Classes/LAppModel.hpp
+++ b/Samples/Cocos2d-x/Demo/Classes/LAppModel.hpp
@@ -12,7 +12,7 @@
 #include <Model/CubismUserModel.hpp>
 #include <ICubismModelSetting.hpp>
 #include <Type/csmRectF.hpp>
-#include <Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp>
+#include <Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.hpp>
 #include "LAppDefine.hpp"
 #include "AppDelegate.h"
 
@@ -203,9 +203,10 @@ private:
     const Csm::CubismId* _idParamEyeBallX;          ///< パラメータID: ParamEyeBallX
     const Csm::CubismId* _idParamEyeBallY;          ///< パラメータID: ParamEyeBallXY
 
-    Csm::Rendering::CubismOffscreenFrame_OpenGLES2  _renderBuffer;  ///< モードによってはCubismOffscreenFrameのテクスチャを描画
+    Csm::Rendering::CubismOffscreenFrame_Cocos2dx  _renderBuffer;  ///< モードによってはCubismOffscreenFrameのテクスチャを描画
     cocos2d::RenderTexture* _renderSprite;          ///< _renderBufferを描画するスプライト
     float _clearColor[4];                           ///< _renderBufferをクリアする際の色
+    Csm::csmVector<cocos2d::Texture2D*> _loadedTextures;
 };
 
 

--- a/Samples/Cocos2d-x/Demo/Classes/LAppSprite.hpp
+++ b/Samples/Cocos2d-x/Demo/Classes/LAppSprite.hpp
@@ -7,7 +7,11 @@
 
 #pragma once
 
-#include "Rendering/OpenGL/CubismRenderer_OpenGLES2.hpp"
+#include "Rendering/Cocos2d/CubismRenderer_Cocos2dx.hpp"
+#include "Rendering/Cocos2d/CubismCommandBuffer_Cocos2dx.hpp"
+#include "cocos2d.h"
+
+USING_NS_CC;
 
 /**
 * @brief スプライトを実装するクラス。
@@ -40,7 +44,7 @@ public:
     * @param[in]       textureId    テクスチャID
     * @param[in]       programId    シェーダID
     */
-    LAppSprite(GLuint programId);
+    LAppSprite(backend::ProgramState* programState);
 
     /**
     * @brief デストラクタ
@@ -51,7 +55,7 @@ public:
     * @brief テクスチャIDを指定して描画する
     *
     */
-    void RenderImmidiate(GLuint textureId, const GLfloat uvVertex[8]) const;
+    void RenderImmidiate(Csm::Rendering::CubismCommandBuffer_Cocos2dx* commandBuffer, Texture2D* texture, float uvVertex[8]) const;
 
     /**
      * @brief 色設定
@@ -67,9 +71,11 @@ private:
 
     int _positionLocation;  ///< 位置アトリビュート
     int _uvLocation;        ///< UVアトリビュート
-    int _textureLocation;   ///< テクスチャアトリビュート
-    int _colorLocation;     ///< カラーアトリビュート
+    backend::UniformLocation _textureLocation;   ///< テクスチャアトリビュート
+    backend::UniformLocation _colorLocation;     ///< カラーアトリビュート
 
     float _spriteColor[4];  ///< 表示カラー
+
+    Csm::Rendering::CubismCommandBuffer_Cocos2dx::DrawCommandBuffer* _drawCommand;
 };
 

--- a/Samples/Cocos2d-x/Demo/Classes/LAppView.cpp
+++ b/Samples/Cocos2d-x/Demo/Classes/LAppView.cpp
@@ -95,15 +95,14 @@ void LAppView::onExit()
 
 void LAppView::draw(cocos2d::Renderer* renderer, const cocos2d::Mat4& transform, uint32_t flags)
 {
+    onDraw(transform, flags);
     DrawNode::draw(renderer, transform, flags);
-
-    _customCommand.init(_globalZOrder);
-    _customCommand.func = CC_CALLBACK_0(LAppView::onDraw, this, transform, flags);
-    renderer->addCommand(&_customCommand);
 }
 
 void LAppView::onDraw(const cocos2d::Mat4& transform, uint32_t flags)
 {
+    _commandBuffer.PushCommandGroup();
+
     Director::getInstance()->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     Director::getInstance()->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, transform);
 
@@ -112,7 +111,7 @@ void LAppView::onDraw(const cocos2d::Mat4& transform, uint32_t flags)
     Live2DMgr->SetViewMatrix(viewMatrix);
 
     // Cubism更新・描画
-    Live2DMgr->OnUpdate();
+    Live2DMgr->OnUpdate(&_commandBuffer);
 
     if (_debugRects)
     {
@@ -120,6 +119,8 @@ void LAppView::onDraw(const cocos2d::Mat4& transform, uint32_t flags)
     }
 
     Director::getInstance()->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
+
+    _commandBuffer.PopCommandGroup();
 }
 
 void LAppView::onTouchesBegan(const std::vector<Touch*>& touches, Event* event)

--- a/Samples/Cocos2d-x/Demo/Classes/LAppView.hpp
+++ b/Samples/Cocos2d-x/Demo/Classes/LAppView.hpp
@@ -47,8 +47,7 @@ private:
     TouchManager* touchMgr;
     Csm::CubismMatrix44* deviceToScreen;
     Csm::CubismViewMatrix* viewMatrix;
+    Csm::Rendering::CubismCommandBuffer_Cocos2dx _commandBuffer;
     DrawNode* _debugRects;
 
-protected:
-    cocos2d::CustomCommand _customCommand;
 };

--- a/Samples/Cocos2d-x/Demo/Classes/SampleScene.cpp
+++ b/Samples/Cocos2d-x/Demo/Classes/SampleScene.cpp
@@ -79,6 +79,7 @@ bool SampleScene::init()
 
     // create menu, it's an autorelease object
     auto closeMenu = Menu::create(_closeItem, NULL);
+    closeMenu->setScale(0.9f);
     closeMenu->setPosition(Vec2::ZERO);
     this->addChild(closeMenu, 1);
 
@@ -97,6 +98,7 @@ bool SampleScene::init()
 
     // create menu, it's an autorelease object
     auto changeMenu = Menu::create(_changeItem, NULL);
+    changeMenu->setScale(0.9f);
     changeMenu->setPosition(Point::ZERO);
     this->addChild(changeMenu, 1);
 

--- a/Samples/Cocos2d-x/Demo/Classes/SampleScene.h
+++ b/Samples/Cocos2d-x/Demo/Classes/SampleScene.h
@@ -9,7 +9,7 @@
 #define __SAMPLE_SCENE_H__
 
 #include "cocos2d.h"
-#include <Rendering/OpenGL/CubismOffscreenSurface_OpenGLES2.hpp>
+#include <Rendering/Cocos2d/CubismOffscreenSurface_Cocos2dx.hpp>
 
 class LAppView;
 

--- a/Samples/Cocos2d-x/Demo/proj.ios/scripts/proj_xcode
+++ b/Samples/Cocos2d-x/Demo/proj.ios/scripts/proj_xcode
@@ -6,11 +6,10 @@ SCRIPT_PATH=$(cd "$(dirname "$0")" && pwd)
 CMAKE_PATH=$SCRIPT_PATH/../..
 BUILD_PATH=$SCRIPT_PATH/../build/proj_xcode
 THIRD_PARTY_DIR=$SCRIPT_PATH/../../../thirdParty
-CMAKE_TOOLCHAIN_FILE=$THIRD_PARTY_DIR/cocos2d/cmake/ios.toolchain.cmake
 
 # Run CMake.
 cmake -S "$CMAKE_PATH" \
   -B "${BUILD_PATH}_iphoneos" \
   -G Xcode \
-  -D IOS_PLATFORM=OS \
-  -D CMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN_FILE"
+  -D CMAKE_SYSTEM_NAME=iOS \
+  -D CMAKE_OSX_SYSROOT=iphoneos

--- a/Samples/Cocos2d-x/Demo/proj.linux/scripts/make_gcc
+++ b/Samples/Cocos2d-x/Demo/proj.linux/scripts/make_gcc
@@ -9,5 +9,7 @@ BUILD_PATH=$SCRIPT_PATH/../build/make_gcc
 # Run CMake.
 mkdir -p "$BUILD_PATH"
 cd "$BUILD_PATH"
-cmake -D CMAKE_BUILD_TYPE=Release "$CMAKE_PATH"
+cmake \
+  -DCMAKE_BUILD_TYPE=Release "$CMAKE_PATH" \
+  -DCMAKE_SYSTEM_NAME=Linux
 make

--- a/Samples/Cocos2d-x/README.md
+++ b/Samples/Cocos2d-x/README.md
@@ -7,8 +7,8 @@ Cocos2d-xで実装したアプリケーションのサンプル実装です。
 
 | フレームワーク | バージョン |
 | --- | --- |
-| [XCode] | 12.1 |
-| [Cocos2d-x] | 3.17.2 |
+| [XCode] | 12.4 |
+| [Cocos2d-x] | 4.0 (`95e5d868ce5958c0dadfc485bdda52f1bc404fe0`) |
 
 その他の開発環境・動作確認環境はトップディレクトリにある [README.md](../../README.md) を参照してください。
 
@@ -21,7 +21,7 @@ Cocos2d-xで実装したアプリケーションのサンプル実装です。
 Cocos2d-x v4.0 から Metal API の対応に伴い、Renderer の構成が変更され、OpenGLES の API を直接使用することが出来なくなりました。
 詳しくは [Cocos2d-x のドキュメント](https://docs.cocos2d-x.org/cocos2d-x/v4/en/upgradeGuide/) を参照してください。
 
-この変更に伴い Cocos2d-x v4.x 系では Cubism Framework の Rendering API を用いることができないため、サポート対象外となります。
+この変更に伴い Cocos2d-x v4.x 系では Cubism Framework の Renderer に Cocos2d-x　専用の物を用意いたしました。現在は、各プラットフォームで共通の Renderer を使用しており、 macOS, Windows, Linux, iOS, Android と横断的にクロスコンパイルを通すことが可能です。
 
 
 ## ディレクトリ構造
@@ -74,6 +74,10 @@ iOS 用の CMake プロジェクトです。
 | --- | --- |
 | `proj_xcode` | Xcode プロジェクト |
 
+ビルド時に下記の手順を行なってください。
+
+1. XCode の `Project設定 - TARGETS - Demo - Packaging - Info.plist File`　に記載されている `Info.plist` 内の `Executable file` を `$(EXECUTABLE_NAME)` または`Demo`（アプリ名）に書き換えてください
+
 NOTICE: Cubism Core は i386 アーキテクチャをサポートしていないため、**iPhone Simulator 向けのビルドは行えません。**
 
 ### proj.linux
@@ -89,11 +93,10 @@ Linux 用の CMake プロジェクトです。
 ビルド前に下記の手順を行なってください。
 
 1. [Dependencies that you need] ドキュメントを参照して必要なパッケージをダウンロードします
-2. `scripts/fix_libs` を実行してライブラリの修正を行います
 
-[Dependencies that you need]: https://docs.cocos2d-x.org/cocos2d-x/v3/en/installation/Linux.html#dependencies-that-you-need
+[Dependencies that you need]: https://docs.cocos2d-x.org/cocos2d-x/v4/en/installation/Linux.html#dependencies-that-you-need
 
-NOTICE: 本プロジェクトは **Ubuntu 18.04 以上**のみのサポートとなります。
+NOTICE: Linuxビルドには制限があります。使用する際は必ずトップディレクトリにある[NOTICE.md](../../NOTICE.md)をご確認ください。
 
 ### proj.mac
 
@@ -105,6 +108,12 @@ macOS 用の CMake プロジェクトです。
 | --- | --- |
 | `make_xcode` | 実行可能なアプリケーション |
 | `proj_xcode` | Xcode プロジェクト |
+
+WARNING: macOSビルドにつきまして、`Cocos2d-x V4.0` に起因する不具合のために正常にビルドができない状態となっております。対処方法につきましては、以下の Issue をご確認ください。
+
+* [cocos2d/cocos2d-x error: Objective-C was disabled in PCH file but is currently enabled
+#20607
+](https://github.com/cocos2d/cocos2d-x/issues/20607#issuecomment-780266298)
 
 ### proj.win
 
@@ -142,7 +151,7 @@ CMake 用の設定ファイルです。
 | Linux / macOS | `setup_cocos2d` |
 | Windows | `setup_cocos2d.bat` |
 
-スクリプト内の `COCOS_VERSION` を変更することでライブラリのバージョンを指定することが出来ます。
+スクリプト内の `COCOS_COMMIT_HASH` を変更することで、使用する Cocos2d-x の SCM 上のバージョンをコミットハッシュで指定することが出来ます。
 
 ダウンロード後は `thirdParty/cocos2d` というディレクトリ名で展開されます。
 

--- a/Samples/Cocos2d-x/thirdParty/scripts/setup_cocos2d
+++ b/Samples/Cocos2d-x/thirdParty/scripts/setup_cocos2d
@@ -2,7 +2,7 @@
 
 set -ue
 
-COCOS_VERSION=3.17.2
+COCOS_COMMIT_HASH=95e5d868ce5958c0dadfc485bdda52f1bc404fe0
 
 SCRIPT_PATH=$(cd $(dirname $0) && pwd)
 
@@ -13,11 +13,14 @@ cd $SCRIPT_PATH/..
 #################
 
 # Download and extract the archive.
-echo - Setup Cocos2d
-echo Downloading...
-curl -fsSL -o cocos2d.zip \
-  https://digitalocean.cocos2d-x.org/Cocos2D-X/cocos2d-x-$COCOS_VERSION.zip
-echo Extracting...
-unzip -oq cocos2d.zip
-mv -f cocos2d-x-* cocos2d
-rm cocos2d.zip
+echo - Setup Cocos2D
+mkdir cocos2d
+cd cocos2d
+git init
+git remote add origin https://github.com/cocos2d/cocos2d-x.git
+git fetch --depth 1 origin ${COCOS_COMMIT_HASH}
+git reset --hard FETCH_HEAD
+python download-deps.py --remove-download yes
+git submodule update --init
+rm -rf .git/
+cd ..

--- a/Samples/Cocos2d-x/thirdParty/scripts/setup_cocos2d.bat
+++ b/Samples/Cocos2d-x/thirdParty/scripts/setup_cocos2d.bat
@@ -1,6 +1,6 @@
 @echo off
 
-set COCOS_VERSION=3.17.2
+set COCOS_COMMIT_HASH=95e5d868ce5958c0dadfc485bdda52f1bc404fe0
 
 set SCRIPT_PATH=%~dp0
 
@@ -12,15 +12,19 @@ cd %SCRIPT_PATH%\..
 
 :: Download and extract the archive.
 echo - Setup Cocos2d
-echo Downloading...
-curl -fsSL -o cocos2d.zip ^
-  "https://digitalocean.cocos2d-x.org/Cocos2D-X/cocos2d-x-%COCOS_VERSION%.zip"
-if %errorlevel% neq 0 pause & exit /b %errorlevel%
-echo Extracting...
-powershell "$progressPreference = 'silentlyContinue'; expand-archive -force cocos2d.zip ."
-if %errorlevel% neq 0 pause & exit /b %errorlevel%
-ren cocos2d-x-%COCOS_VERSION% cocos2d
-del cocos2d.zip
+cd ..\..\..\
+mkdir _l2d_tmp
+cd _l2d_tmp
+git init
+git remote add origin https://github.com/cocos2d/cocos2d-x.git
+git fetch --depth 1 origin %COCOS_COMMIT_HASH%
+git reset --hard FETCH_HEAD
+python "download-deps.py" "--remove-download" "yes"
+git submodule update --init
+rmdir /s /q .git
+cd ..
+robocopy _l2d_tmp %SCRIPT_PATH%\..\cocos2d /MIR
+rmdir /s /q _l2d_tmp
 
 echo.
 pause

--- a/Samples/D3D11/Demo/proj.d3d11.cmake/src/LAppDelegate.cpp
+++ b/Samples/D3D11/Demo/proj.d3d11.cmake/src/LAppDelegate.cpp
@@ -84,12 +84,15 @@ bool LAppDelegate::Initialize()
     ShowWindow(_windowHandle, SW_SHOWDEFAULT);
     UpdateWindow(_windowHandle);
 
+    // 現在のウィンドウサイズ
+    int windowWidth, windowHeight;
+    GetClientSize(windowWidth, windowHeight);
 
     // デバイス設定
     memset(&_presentParameters, 0, sizeof(_presentParameters));
     _presentParameters.BufferCount = BackBufferNum;
-    _presentParameters.BufferDesc.Width = LAppDefine::RenderTargetWidth;
-    _presentParameters.BufferDesc.Height = LAppDefine::RenderTargetHeight;
+    _presentParameters.BufferDesc.Width = windowWidth;
+    _presentParameters.BufferDesc.Height = windowHeight;
     _presentParameters.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     _presentParameters.BufferDesc.RefreshRate.Numerator = 60;
     _presentParameters.BufferDesc.RefreshRate.Denominator = 1;


### PR DESCRIPTION
### Added

* Add the sample for Cocos2d-x v4.0.

### Removed

* Obsolete the sample for Cocos2d-x v3.x.

### Fixed

* Fix setup scripts for Cocos2d-x.
  * Changed from xcopy to robocopy and improved to be able to place in a deep hierarchy.
* Fixed initial window size display misalignment when scaling is set in D3D11.
