### PR TITLE
Update to Cubism 4 SDK for Native R6_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [4-r.6.2] - 2023-03-16
+
+### Changed
+
+* Change to make it easier to use double and triple buffers on DirectX systems.
+
+### Fixed
+
+* Fix some problems related to Cubism Core.
+  * See `CHANGELOG.md` in Core.
+
+
 ## [4-r.6.1] - 2023-03-10
 
 ### Added
@@ -273,6 +285,7 @@ See [Core Changelog] for details.
 * What was `Package.json` is currently being changed to`cubism-info.yml`.
 
 
+[4-r.6.2]: https://github.com/Live2D/CubismNativeSamples/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismNativeSamples/compare/4-r.6...4-r.6.1
 [4-r.6]: https://github.com/Live2D/CubismNativeSamples/compare/4-r.5.1...4-r.6
 [4-r.5.1]: https://github.com/Live2D/CubismNativeSamples/compare/4-r.5...4-r.5.1

--- a/Core/CHANGELOG.md
+++ b/Core/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2023-03-16
+
+### Fixed
+
+* Fix a case in which the index of the mask's drawable object was negative value for `csmGetDrawableMasks()`.
+* Fix a problem in which `csmHasMocConsistency()` was returned as 0 even though the MOC3 file was in the correct format.
+  * This problem was occurring in some models using the blendshape weight limit settings.
+* Fix a problem that could cause a crash if a MOC3 file that is not in the correct format is loaded with `csmHasMocConsistency()`.
+
+### Changed
+
+* Upgrade Core version to 04.02.0004.
+
+
 ## 2023-03-10
 
 ### Added

--- a/Samples/D3D9/Demo/proj.d3d9.cmake/src/LAppDelegate.cpp
+++ b/Samples/D3D9/Demo/proj.d3d9.cmake/src/LAppDelegate.cpp
@@ -22,6 +22,9 @@ namespace {
     LAppDelegate* s_instance = NULL;
 
     const LPCSTR ClassName = "Cubism DirectX9 Sample";
+
+    // デフォルトバックバッファ作成枚数
+    const csmInt32 BackBufferNum = 1;
 }
 
 LAppDelegate* LAppDelegate::GetInstance()
@@ -86,9 +89,6 @@ bool LAppDelegate::Initialize()
         LAppPal::PrintLog("Fail Direct3D Initialize");
         return false;
     }
-
-    // デフォルトバックバッファ作成枚数
-    const csmInt32 BackBufferNum = 1;
 
     // デバイス設定
     memset(&_presentParameters, 0, sizeof(_presentParameters));
@@ -230,7 +230,7 @@ void LAppDelegate::InitializeCubism()
     CubismFramework::Initialize();
 
     // モデルロード前に必ず呼び出す必要がある
-    Live2D::Cubism::Framework::Rendering::CubismRenderer_D3D9::InitializeConstantSettings(1, _device);
+    Live2D::Cubism::Framework::Rendering::CubismRenderer_D3D9::InitializeConstantSettings(BackBufferNum, _device);
 
     //load model
     LAppLive2DManager::GetInstance();
@@ -481,7 +481,7 @@ void LAppDelegate::EndFrame()
             else
             {
                 // デバイスが変わったことを通知
-                Live2D::Cubism::Framework::Rendering::CubismRenderer_D3D9::InitializeConstantSettings(1, _device);
+                Live2D::Cubism::Framework::Rendering::CubismRenderer_D3D9::InitializeConstantSettings(BackBufferNum, _device);
 
                 // 描画のパラメータをウィンドウサイズに合わせて新設定
                 _view->Initialize();


### PR DESCRIPTION
### Changed

* Change to make it easier to use double and triple buffers on DirectX systems.

### Fixed

* Fix some problems related to Cubism Core.
  * See `CHANGELOG.md` in Core.