### PR TITLE
Update to Cubism 5 SDK for Native R5 beta3_1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.5-beta.3.1] - 2026-02-19
+
+### Fixed
+
+* Fix a bug where rendering results were not as expected when using Blend mode on semi-transparent objects.
+  * See `CHANGELOG.md` in Framework.
+
+
 ## [5-r.5-beta.3] - 2026-01-29
 
 ### Added
@@ -572,6 +580,7 @@ See [Core Changelog] for details.
 * What was `Package.json` is currently being changed to`cubism-info.yml`.
 
 
+[5-r.5-beta.3.1]: https://github.com/Live2D/CubismNativeSamples/compare/5-r.5-beta.3...5-r.5-beta.3.1
 [5-r.5-beta.3]: https://github.com/Live2D/CubismNativeSamples/compare/5-r.5-beta.2...5-r.5-beta.3
 [5-r.5-beta.2]: https://github.com/Live2D/CubismNativeSamples/compare/5-r.5-beta.1...5-r.5-beta.2
 [5-r.5-beta.1]: https://github.com/Live2D/CubismNativeSamples/compare/5-r.4.1...5-r.5-beta.1


### PR DESCRIPTION
### Fixed

* Fix a bug where rendering results were not as expected when using Blend mode on semi-transparent objects.
  * See `CHANGELOG.md` in Framework.